### PR TITLE
Añadidos dos parámetros

### DIFF
--- a/Openscad/Code_Config.scad
+++ b/Openscad/Code_Config.scad
@@ -9,6 +9,12 @@
 
 $fn = 100;
 
+// Cojinetes Lineales
+dCoLi = 16.2 ;	// Diámetro
+
+// Varillas lisas
+dVaLi = 8.15 ; // Diámetro
+
 
 //************************************//
 //        Módulos de uso global       //


### PR DESCRIPTION
Se han añadido dos parámetros faltantes de los cojinetes lineales (dCoLi
y dVaLi) que provocaban errores en algunas piezas.
